### PR TITLE
Eager load/42

### DIFF
--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -5,7 +5,7 @@ class CommunitiesController < ApplicationController
     @subscribed_user = @community.user_communities.includes(:user)
     @members = User.where(id: @subscribed_user.pluck(:user_id))
     @posts = @community.community_posts.eager_load(:user, :image_tags).order(created_at: :desc)
-      .page(params[:page]).per(100).search(params[:search])
+      .page(params[:page]).per(10).search(params[:search])
     @post_comments = PostComment.eager_load(:user)
     @new_post = CommunityPost.new
     if params[:post_community_id]

--- a/app/controllers/communities_controller.rb
+++ b/app/controllers/communities_controller.rb
@@ -6,11 +6,11 @@ class CommunitiesController < ApplicationController
     @members = User.where(id: @subscribed_user.pluck(:user_id))
     @posts = @community.community_posts.eager_load(:user, :image_tags).order(created_at: :desc)
       .page(params[:page]).per(10).search(params[:search])
-    @post_comments = PostComment.eager_load(:user)
+    @post_comments = PostComment.eager_load(:user).limit(8).order(created_at: :desc)
     @new_post = CommunityPost.new
     if params[:post_community_id]
       @select_post = CommunityPost.find(params[:post_community_id])
-      @comments = @select_post.post_comments.limit(8).order(created_at: :desc)
+      @comments = @select_post.post_comments.includes(:user).limit(8).order(created_at: :desc)
       @new_comment = PostComment.new
     end
   end

--- a/app/controllers/community_posts_controller.rb
+++ b/app/controllers/community_posts_controller.rb
@@ -17,7 +17,7 @@ class CommunityPostsController < ApplicationController
       @subscribed_user = @community.user_communities.includes(:user)
       @members = User.where(id: @subscribed_user.pluck(:user_id))
       @post_comments = PostComment.eager_load(:user)
-      @posts = @community.community_posts.order(created_at: :desc).page(params[:page]).per(100).search(params[:search])
+      @posts = @community.community_posts.order(created_at: :desc).page(params[:page]).per(10).search(params[:search])
       @new_post = post
       flash.now[:danger] = CommunityPost.create_error_message(post)
       render 'communities/show'


### PR DESCRIPTION
close #42
パフォーマンス向上のため、N+1問題の対策をしました。

community_postsは、users, image_tagsとjoinするSQLを発行。

post_comments取得のためのSQL発行量を抑えるため、
community_postsを10件ずつ取得して表示するようにしました。